### PR TITLE
Fix issue: dpkg cannot install from URL directly.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,12 +28,8 @@ class xymon::params {
 
     case $::osfamily {
       'Debian'           : {
-        if ($::architecture == 'amd64') {
-          $default_client_package_file = 'http://downloads.sourceforge.net/project/xymon/Xymon/4.3.17/xymon-client_4.3.17_amd64.deb'
-        } else {
-          $default_client_package_file = 'http://downloads.sourceforge.net/project/xymon/Xymon/4.3.17/xymon-client_4.3.17_i386.deb'
-        }
-        $default_client_package_provider = 'dpkg'
+        $default_client_package_file = 'xymon-client'
+        $default_client_package_provider = 'apt'
       }
       'RedHat': {
         case $::operatingsystem {


### PR DESCRIPTION
dpkg doesn't support installing deb-packages from a URL directly. The Debian repository contains xymon-client packages (see https://packages.debian.org/jessie/xymon-client). Let's use apt with xymon-client instead.